### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "grunt-contrib-uglify": "^1.0.2",
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.11",
-    "npm": "^6.9.0",
     "passport": "^0.3.2",
     "passport-local": "^1.0.0",
     "path": "^0.12.7",


### PR DESCRIPTION

Hello colinchmiller!

It seems like you have npm as one of your (dev-) dependency in eggplant_chickens.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
